### PR TITLE
Add "pause" instruction for POWER processor

### DIFF
--- a/helper/odph_pause.h
+++ b/helper/odph_pause.h
@@ -44,6 +44,9 @@ static inline void odph_pause(void)
 	__asm__ __volatile__ ("nop");
 	__asm__ __volatile__ ("nop");
 
+#elif defined __powerpc__
+	__asm__ __volatile__ ("ori 27, 27, 27");
+
 #endif
 }
 


### PR DESCRIPTION
POWER processor uses "ori 27, 27, 27" to yield processor in a multithread
environment.

This patch just make this change.